### PR TITLE
Fix outdated debug message in train.sh

### DIFF
--- a/chess-AI/train.sh
+++ b/chess-AI/train.sh
@@ -7,5 +7,5 @@ if [ "$1" = "streamlit" ]; then
 elif [ "$1" = "json" ]; then
     python train.py -j
 else
-    echo "Expected first argument to be either <streamlit> or <cli>"
+    echo "Expected first argument to be either <streamlit> or <json>"
 fi


### PR DESCRIPTION
When arg is not streamlit or json, train.sh currently prints
`"Expected first argument to be either <streamlit> or <cli>"` which is incorrect.