### PR TITLE
Removed homing and added print statements

### DIFF
--- a/firmware/arduino/chessboard/chessboard.ino
+++ b/firmware/arduino/chessboard/chessboard.ino
@@ -179,14 +179,14 @@ void setup()
   ledcSetup(EM_PWM_CHANNEL, PWM_FREQUENCY, PWM_RESOLUTION);
   ledcAttachPin(ELECTROMAGNET, EM_PWM_CHANNEL);
 
-  // Homes the EM to the origin and sets currPositionX/Y to 0
-  home();
-
   // Initializes global 2d array `pulsesPerSlope` which is used to define circle paths
   // that are used in the `makeCircle()` function in circleFunction.ino
   calculatePulsesPerSlope();
 
   Serial2.begin(115200, SERIAL_8N1, RX2, TX2);
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting Program...");
   
   attachInterrupt(digitalPinToInterrupt(CHESS_TIMER_BUTTON), chessTimerISR, RISING);
 }

--- a/firmware/raspi/boardinterface.py
+++ b/firmware/raspi/boardinterface.py
@@ -522,7 +522,7 @@ class Board:
         '''Add Instruction to self.msg_queue.
         '''
         self.instruction_count += 1
-        instruction = Instruction(op_type, self.instruction_count, extra)
+        instruction = Instruction(op_type, self.instruction_count % 2, extra)
         self.add_message_to_queue(instruction, add_to_front=True)
 
     def add_message_to_queue(self, message, add_to_front=False):

--- a/firmware/raspi/cliinterface.py
+++ b/firmware/raspi/cliinterface.py
@@ -4,6 +4,7 @@ import random
 
 from game import Game
 import player
+import status
 from util import parse_args
 
 # TODO: make this function have a better name; it doesn't just return bool, it also assigns color.
@@ -89,6 +90,8 @@ def main():
     mode_of_interaction = params["mode_of_interaction"]
     print(f"\nRUNNING IN {mode_of_interaction.upper()} MODE...\n")
 
+    # Note: If running in test or debug, need to call `alignAxis()` for xmin and ymin explicitly.
+    # All other modes perform homing before entering main game loop.
     if params["mode_of_interaction"] == "test":
         game = Game(params["mode_of_interaction"])
         # TODO: Refactor to handle dispatching moves using the code in `process`.
@@ -101,6 +104,10 @@ def main():
     elif params["mode_of_interaction"] in ("cli", "otb", "web", "speech"):
         game = Game(params["mode_of_interaction"], params["human_plays_white_pieces"])
         # _, human_plays_white_pieces, board, ai_player = params
+
+        # Sends two instruction messages for homing, 1st for min x, 2nd for min y
+        game.board.add_instruction_to_queue(op_type=status.OpType.ALIGN_AXIS, extra='0')
+        game.board.add_instruction_to_queue(op_type=status.OpType.ALIGN_AXIS, extra='1')
 
     # Main game loop
     current_player = 0

--- a/firmware/raspi/status.py
+++ b/firmware/raspi/status.py
@@ -85,17 +85,18 @@ class OpType:
     '''Enum of op types used to provide information about OpCode.INSTRUCTION types.
     '''
     # This code indicates Arduino should align an axis
-    # Setting first info bit (e.g. msg[2]) to '0' indicates aligning to zero, '1' indicates
-    # aligning to max
-    ALIGN_AXIS = '1'
+    # Setting first info bit (e.g. msg[2]) to '0' indicates aligning x axis to zero, '1' indicates
+    # aligning y axis to zero, '2' indicates aligning x axis to max, '3' indicates aligning y axis
+    # to max.
+    ALIGN_AXIS = 'A'
 
     # This code indicates Arduino should set the state of the electromagnet
     # Setting first info bit (e.g. msg[2]) to '0' indicates OFF, '1' indicates ON
-    SET_ELECTROMAGNET = '2'
+    SET_ELECTROMAGNET = 'S'
 
     # This code indicates Arduino should retransmit last message
     # This code used when a corrupted or misaligned message is received
-    RETRANSMIT_LAST_MSG = '3'
+    RETRANSMIT_LAST_MSG = 'R'
 
     # Tuple of all OpTypes, used for checking membership
     VALID_OPS = (ALIGN_AXIS, SET_ELECTROMAGNET, RETRANSMIT_LAST_MSG)

--- a/firmware/raspi/util.py
+++ b/firmware/raspi/util.py
@@ -238,7 +238,7 @@ def parse_args():
 
     return parser.parse_args()
 
-def transpose_board_cell(boardcell):
+def transpose_boardcell(boardcell):
     """Transpose board cell from white pieces on human side (default) to black on human side.
 
     If you transpose a board cell twice, you get the original location.
@@ -248,6 +248,7 @@ def transpose_board_cell(boardcell):
     return BoardCell(Const.BOARD_SIZE - boardcell.row, Const.BOARD_SIZE - boardcell.col)
 
 class Const:
+    """Helper file storing various constants used for KG program."""
     CELLS_PER_SQ = 2
     OFFSET_SIZE = 4
     BOARD_SIZE = 22


### PR DESCRIPTION
Calling the homing function in `setup()` causes the program to not start if no endstops are hooked up. We may want to test the system without them in debug mode or something, so we'll have the Raspberry Pi send the homing commands over UART.

The print statements are to make it clear that the setup function has executed correctly and is now entering the main loop.